### PR TITLE
pull in opa-java as an api dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.0.5 (unreleased)
 
 * Add `OPAAuthorizationManager` constructor that accepts a path and a `ContextDataProvider`, but not an `OPAClient`.
+* `opa-java` is now marked as an `api` dependency in `build.gradle`, so it will not be transitively exposed to users.
 
 ## v0.0.4
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:+'
     testImplementation 'org.mockito:mockito-junit-jupiter:+'
 
-    implementation group: 'com.styra', name: 'opa', version: '1.4.1'
+    api group: 'com.styra', name: 'opa', version: '1.4.1'
 
     compileOnly 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'java-library'
     id 'maven-publish'
     id 'signing'
     id 'org.springframework.boot' version '3.3.2'


### PR DESCRIPTION
This means anyone pulling in opa-springboot should not need to separately add opa-java to their build.gradle in order to use it.