### PR TITLE
Fix null pointer crash with some Authentication implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.0.6 (unreleased)
 
+* Fixed a null pointer exception while constructing the input to OPA with some Authentication implementations.
+
 ## v0.0.5
 
 * Add `OPAAuthorizationManager` constructor that accepts a path and a `ContextDataProvider`, but not an `OPAClient`.

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,13 @@ repositories {
     mavenCentral()
 }
 
+javadoc {
+    options.links += [
+        "https://styrainc.github.io/opa-java/javadoc/",
+        "https://docs.spring.io/spring-security/site/docs/current/api/",
+    ]
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.security:spring-security-web'


### PR DESCRIPTION
Java does not like it when you insert null as a value into a `Map<String, Object>`, which could cause the AuthorizationManager to experience a null pointer exception if the Authentication implementation returned null for certain fields. This PR adds a test to trigger the bad behavior, and updates the AuthorizationManager to get the new test to pass.