### PR TITLE
Release v0.0.8: remove classifier from jar build

### DIFF
--- a/.github/workflows/01_test_and_lint.yaml
+++ b/.github/workflows/01_test_and_lint.yaml
@@ -15,7 +15,8 @@ jobs:
           distribution: "corretto"
           cache: "gradle"
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew test lint checkstyleMain checkstyleTest
+      - run: ./gradlew test lint checkstyleMain checkstyleTest jar
+      - run: ls -al build/libs
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: success() || failure() # always run even if the previous step fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # OPA Spring Boot SDK Changelog
 
-## v0.0.8 (unreleased)
+## v0.0.8
+
+* Change `build.gradle` to omit the `plain` classifier from the jar file it builds. This should make the default
+  snippet show on https://central.sonatype.com/artifact/com.styra.opa/springboot _work as is_. Before, you would
+  have to add `<classifier>plain</classifier>`.
 
 ## v0.0.7
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
-    id 'org.springframework.boot' version '3.3.2'
+    id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
     id("checkstyle")
 }
@@ -14,13 +14,20 @@ version = '0.0.8'
 java {
     sourceCompatibility = '17'
     targetCompatibility = '17'
-
 }
 
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+}
+
+tasks.named("bootJar") {
+    archiveClassifier = 'boot'
+}
+
+tasks.named("jar") {
+    archiveClassifier = ''
 }
 
 repositories {


### PR DESCRIPTION
Change `build.gradle` to omit the `plain` classifier from the jar file it builds. This should make the default
  snippet show on https://central.sonatype.com/artifact/com.styra.opa/springboot _work as is_. Before, you would
  have to add `<classifier>plain</classifier>`.

-------
### References
* https://docs.gradle.org/current/userguide/publishing_maven.html
* https://docs.spring.io/spring-boot/gradle-plugin/packaging.html
