### PR TITLE
Autowire `OPAProperties` in `OPAAutoConfiguration`

### DIFF
--- a/src/main/java/com/styra/opa/springboot/OPAAuthorizationManager.java
+++ b/src/main/java/com/styra/opa/springboot/OPAAuthorizationManager.java
@@ -147,7 +147,7 @@ public class OPAAuthorizationManager
     }
 
     @PostConstruct
-    public void init() {
+    private void init() {
         if (opaPath == null) {
             opaPath = opaProperties.getPath();
         }

--- a/src/main/java/com/styra/opa/springboot/OPAAuthorizationManager.java
+++ b/src/main/java/com/styra/opa/springboot/OPAAuthorizationManager.java
@@ -7,6 +7,7 @@ import com.styra.opa.springboot.autoconfigure.OPAProperties;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -43,6 +44,7 @@ public class OPAAuthorizationManager
 
     private OPAClient opa;
 
+    @Autowired(required = false)
     private OPAProperties opaProperties;
 
     /**

--- a/src/test/java/com/styra/opa/springboot/autoconfigure/OPAAutoConfigurationTest.java
+++ b/src/test/java/com/styra/opa/springboot/autoconfigure/OPAAutoConfigurationTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.Map;
 
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @SpringBootTest(classes = OPAAutoConfiguration.class)
 public class OPAAutoConfigurationTest {
 
+    @TestPropertySource(properties = { "opa.response.context.reason-key=fr" })
     @Nested
     public class DefaultOPAAutoConfigurationTest {
 
@@ -33,6 +35,15 @@ public class OPAAutoConfigurationTest {
             assertNotNull(opaProperties);
             assertNotNull(opaClient);
             assertNotNull(opaAuthorizationManager);
+        }
+
+        /**
+         * Make sure that {@link #opaProperties} bean is autowired in {@link #opaAuthorizationManager}.
+         */
+        @Test
+        public void testOPAPropertiesBeanAutowiring() {
+            assertEquals("fr", opaProperties.getResponse().getContext().getReasonKey());
+            assertEquals("fr", opaAuthorizationManager.getReasonKey());
         }
     }
 


### PR DESCRIPTION
- To properly using configuration properties loaded by `OPAProperties`, this bean should be autowired in `OPAAutoConfiguration` bean.
- To keep `opaProperties` object immutable, `opaPath` field has been restored.
  -  `opaPath` can be set by constructors.
  - If `opaPath` is not set and current object (`opaAuthorizationManager`) is instantiated as a Spring bean, it will be set based on `opaProperties.getPath()`.

Related to #22