### PR TITLE
feat: add OPAPathSelector to customize path selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,11 @@ On Windows:
 gradlew.bat publishToMavenLocal -"Pskip.signing"
 ```
 
-## SDK Example Usage (high-level)
-
+## SDK Example Usage
+### OPAAuthorizationManager
 Using `OPAAuthorizationManager`, HTTP requests could be authorized:
 
 ```java
-// ... 
-
 import com.styra.opa.springboot.OPAAuthorizationManager;
 import com.styra.opa.OPAClient;
 
@@ -49,12 +47,12 @@ public class SecurityConfig {
         // Other security configs
         return http.build();
     }
-
 }
 ```
-Auto-configuration will be done using `OPAAutoConfiguration`. If any customization would be needed, custom `OPAClient`
-or `OPAAuthorizationManager` beans could be defined.
+Auto-configuration will be done using `OPAAutoConfiguration`. If any customization be needed, custom `OPAClient`
+or `OPAAuthorizationManager` beans could be defined by clients.
 
+### OPAProperties
 Configuration properties are defined in `OPAProperties` and can be set
 [externally](https://docs.spring.io/spring-boot/reference/features/external-config.html), e.g. via
 `application.properties`, `application.yaml`, system properties, or environment variables.
@@ -74,6 +72,30 @@ opa:
     response:
         context:
             reason-key: de # Key to search for decision reasons in the response. Default is "en".
+```
+### OPAPathSelector
+By default, OPAAuthorizationManager does not use any path when calling OPA (evaluating policies). Clients could define
+an `OPAPathSelector` bean, which could select paths based on the `Authentication`, `RequestAuthorizationContext`, or
+opaRequestBody `Map`.
+
+Example `OPAPathSelector` bean:
+```java
+@Configuration
+public class OPAConfig {
+    @Bean
+    public OPAPathSelector opaPathSelector() {
+        return (authentication, requestAuthorizationContext, opaRequestBody) -> {
+            String httpRequestPath = requestAuthorizationContext.getRequest().getServletPath();
+            if (httpRequestPath.startsWith("/foo")) {
+                return "foo/main";
+            } else if (httpRequestPath.startsWith("/bar")) {
+                return "bar/main";
+            } else {
+                return "default/main";
+            }
+        };
+    }
+}
 ```
 
 ## Policy Input/Output Schema

--- a/src/main/java/com/styra/opa/springboot/OPAPathSelector.java
+++ b/src/main/java/com/styra/opa/springboot/OPAPathSelector.java
@@ -1,0 +1,16 @@
+package com.styra.opa.springboot;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+
+import java.util.Map;
+
+/**
+ * Select target OPA path based on {@link Authentication}, {@link RequestAuthorizationContext}, and
+ * opaRequestBody {@link Map}.
+ */
+@FunctionalInterface
+public interface OPAPathSelector {
+    String selectPath(Authentication authentication, RequestAuthorizationContext requestAuthorizationContext,
+                      Map<String, Object> opaRequestBody);
+}

--- a/src/main/java/com/styra/opa/springboot/autoconfigure/OPAAutoConfiguration.java
+++ b/src/main/java/com/styra/opa/springboot/autoconfigure/OPAAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.styra.opa.springboot.autoconfigure;
 
 import com.styra.opa.OPAClient;
 import com.styra.opa.springboot.OPAAuthorizationManager;
+import com.styra.opa.springboot.OPAPathSelector;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -27,6 +28,15 @@ public class OPAAutoConfiguration {
     @ConditionalOnMissingBean(OPAClient.class)
     public OPAClient opaClient(OPAProperties opaProperties) {
         return new OPAClient(opaProperties.getUrl());
+    }
+
+    /**
+     * Create an {@link OPAPathSelector} bean using {@link OPAProperties#getPath()}.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public OPAPathSelector opaPathSelector(OPAProperties opaProperties) {
+        return (authentication, requestAuthorizationContext, opaRequestBody) -> opaProperties.getPath();
     }
 
     /**

--- a/src/test/java/com/styra/opa/springboot/autoconfigure/OPAAutoConfigurationTest.java
+++ b/src/test/java/com/styra/opa/springboot/autoconfigure/OPAAutoConfigurationTest.java
@@ -2,6 +2,7 @@ package com.styra.opa.springboot.autoconfigure;
 
 import com.styra.opa.OPAClient;
 import com.styra.opa.springboot.OPAAuthorizationManager;
+import com.styra.opa.springboot.OPAPathSelector;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,12 +29,15 @@ public class OPAAutoConfigurationTest {
         @Autowired(required = false)
         private OPAClient opaClient;
         @Autowired(required = false)
+        private OPAPathSelector opaPathSelector;
+        @Autowired(required = false)
         private OPAAuthorizationManager opaAuthorizationManager;
 
         @Test
         public void testDefaultBeansExistence() {
             assertNotNull(opaProperties);
             assertNotNull(opaClient);
+            assertNotNull(opaPathSelector);
             assertNotNull(opaAuthorizationManager);
         }
 
@@ -67,6 +71,30 @@ public class OPAAutoConfigurationTest {
             @Bean
             public OPAClient customOPAClient() {
                 return new OPAClient("http://localhost:8182");
+            }
+        }
+    }
+
+    @Import(OPAAutoConfigurationTestWithCustomOPAPathSelector.CustomOPAPathSelectorConfiguration.class)
+    @Nested
+    public class OPAAutoConfigurationTestWithCustomOPAPathSelector {
+
+        @Autowired(required = false)
+        private Map<String, OPAPathSelector> opaPathSelectors;
+
+        @Test
+        public void testCustomOPAPathSelectorBeanExistence() {
+            assertNotNull(opaPathSelectors);
+            assertEquals(1, opaPathSelectors.size());
+            assertNotNull(opaPathSelectors.get("customOPAPathSelector"));
+        }
+
+        @Configuration
+        public static class CustomOPAPathSelectorConfiguration {
+
+            @Bean
+            public OPAPathSelector customOPAPathSelector() {
+                return (authentication, requestAuthorizationContext, opaRequestBody) -> "foo/bar";
             }
         }
     }


### PR DESCRIPTION
Add `OPAPathSelector` to enable clients to customize OPA path selection.

Implements #23 