### PR TITLE
Update the publishing actions to prepare for sonatype migration

### DIFF
--- a/.github/workflows/03_publish_to_maven.yaml
+++ b/.github/workflows/03_publish_to_maven.yaml
@@ -26,15 +26,15 @@ jobs:
         if: ${{ steps.build.outputs.release  == 'true' }}
       - uses: gradle/actions/setup-gradle@v4
         if: ${{ steps.build.outputs.release  == 'true' }}
-      - name: Publish to Sonatype (legacy)
+      - name: Publish to Sonatype Central
         run: |-
           pwd
-          ./gradlew publish --no-daemon
+          ./gradlew build sonatypeCentralUpload --no-daemon
         env:
-          MAVEN_USERNAME: ${{ secrets.ossrh_username }}
-          MAVEN_PASSWORD: ${{ secrets.ossrh_password }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.java_gpg_secret_key }}
-          ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.java_gpg_passphrase }}
+          SONATYPE_USERNAME: ${{ secrets.sonatype_username }}
+          SONATYPE_PASSWORD: ${{ secrets.sonatype_password }}
+          SONATYPE_SIGNING_KEY: ${{ secrets.java_gpg_secret_key }}
+          SIGNING_KEY_PASSPHRASE: ${{ secrets.java_gpg_passphrase }}
         if: ${{ steps.build.outputs.release  == 'true' }}
       - uses: ravsamhq/notify-slack-action@v2
         if: ${{ steps.build.outputs.release  == 'true' && always() && env.SLACK_WEBHOOK_URL != '' }}

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,6 @@ plugins {
     id("checkstyle")
 }
 
-group = 'com.styra'
-version = '1.0.1'
-
 java {
     sourceCompatibility = '17'
     targetCompatibility = '17'
@@ -150,9 +147,9 @@ sonatypeCentralUpload {
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = 'com.styra.opa'
-            artifactId = 'springboot'
-            version = version
+            groupId = "${groupId}"
+            artifactId = "${artifactId}"
+            version = "${version}"
 
             from components.java
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
+    id 'cl.franciscosolis.sonatype-central-upload' version '1.0.3'
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
     id("checkstyle")
@@ -124,19 +125,29 @@ gradle.projectsEvaluated {
     }
 }
 
+sonatypeCentralUpload {
+    // This is your Sonatype generated username
+    username = System.getenv("SONATYPE_USERNAME")
+    // This is your sonatype generated password
+    password = System.getenv("SONATYPE_PASSWORD")
+
+    // This is a list of files to upload. Ideally you would point to your jar file, source and javadoc jar (required by central)
+    archives = files(
+      "$buildDir/libs/${artifactId}-${version}.jar",
+      "$buildDir/libs/${artifactId}-${version}-sources.jar",
+      "$buildDir/libs/${artifactId}-${version}-javadoc.jar"
+    )
+
+    // This is the pom file to upload. This is required by central
+    pom = file("$buildDir/pom.xml")
+
+    // This is your PGP private key. This is required to sign your files
+    signingKey = System.getenv("SONATYPE_SIGNING_KEY")
+    // This is your PGP private key passphrase to decrypt your private key
+    signingKeyPassphrase = System.getenv("SIGNING_KEY_PASSPHRASE")
+}
 
 publishing {
-    repositories {
-        maven {
-            name = "OSSRH"
-            url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-            credentials {
-                username = System.getenv("MAVEN_USERNAME")
-                password = System.getenv("MAVEN_PASSWORD")
-          }
-        }
-    }
-
     publications {
         maven(MavenPublication) {
             groupId = 'com.styra.opa'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+groupId = 'com.styra.opa'
+artifactId = 'springboot'
+version = '1.0.1'


### PR DESCRIPTION
Related to https://github.com/StyraInc/opa-java/pull/84

I've already updated the secrets in the repository 