### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 2.0.0
+
+This release includes a breaking change: updating to [Spring Boot 4.0.3](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes).
+Also included are dependency updates and CI improvements.
+
+
 ## 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5
 
 These releases include release engineering improvements, with no significant code or dependency changes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 groupId=io.github.open-policy-agent.opa
 artifactId=springboot
-version=1.0.5
+version=2.0.0


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

We're cutting a new release to get the [Spring Boot 4 upgrade](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes) out there. This also gives us a chance to test the newly updated CI jobs.

### :chains: Related Resources

