### PR TITLE
ci: Fix docs build workflow permissions.

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -12,16 +12,17 @@ jobs:
   docs:
     name: Docs Build and Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed for pushing changes to Github Pages.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          persist-credentials: true # Needed for the Github Pages deployment.
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "17"
           distribution: "corretto"
-          cache: "gradle"
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
           cache-disabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.0.1
+
+This release fixes a Github Actions workflow bug that broke docs publishing.
+
+
 ## 2.0.0
 
 This release includes a breaking change: updating to [Spring Boot 4.0.3](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes).


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

The docs build failed during the last release, due to insufficient permissions. This is because I locked it down a little too much in #66. I've added back write permissions, so that it can push the docs branch contents up again.

### :athletic_shoe: How to test

 - Cut another release, see if docs publish successfully.

### :chains: Related Resources

